### PR TITLE
wait for device symlink

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -244,10 +244,9 @@ function disk_create_partition() {
         local new_device
 	new_device="$(resolve_device_by_id "$new_id")" \
 		|| die "Could not resolve new device with id=$new_id"
-        for i in `seq 10`; do
-                if [ -f "$new_device" ]; then
-                        break
-                fi
+        for i in {1..10}; do
+                [[ -f "$new_device" ]] && break
+                echo "Waiting for partition $new_device to appear, $i second..."
                 sleep 1
         done
 }

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -239,6 +239,17 @@ function disk_create_partition() {
 	sgdisk -n "0:0:$arg_size" -t "0:$type" -u "0:$partuuid" $extra_args "$device" >/dev/null \
 		|| die "Could not create new gpt partition ($new_id) on '$device' ($id)"
 	partprobe "$device"
+
+        # On some system, we need to wait a bit for the $new_id symlink to show up.
+        local new_device
+	new_device="$(resolve_device_by_id "$new_id")" \
+		|| die "Could not resolve new device with id=$new_id"
+        for i in `seq 10`; do
+                if [ -f "$new_device" ]; then
+                        break
+                fi
+                sleep 1
+        done
 }
 
 function disk_create_raid() {


### PR DESCRIPTION
On some systems, the new partition's symlink seems to take a little time to show up even after calling partprobe. Adding this small loop seems to fix it. Don't know if this is the right fix or what additional tests should I do. It tested working on my system.

Without it, the error I ran into is "mkfs.fat" errors out with a "device not found" error.