### PR TITLE
Fix booting from encrypted root filesystem with systemd

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -401,6 +401,14 @@ EOF
 		try emerge --verbose sys-fs/cryptsetup
 	fi
 
+	if [[ $SYSTEMD == "true" && $USED_LUKS == "true" ]] ; then
+		einfo "Enabling cryptsetup USE flag"
+		echo 'USE="cryptsetup"' >> /etc/portage/make.conf \
+			|| die "Could not append to /etc/portage/make.conf"
+		einfo "Remerging @world with cryptsetup"
+		try emerge --verbose --changed-use --deep @world
+	fi
+
 	# Install btrfs-progs if we used btrfs
 	if [[ $USED_BTRFS == "true" ]]; then
 		einfo "Installing btrfs-progs"

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -402,11 +402,11 @@ EOF
 	fi
 
 	if [[ $SYSTEMD == "true" && $USED_LUKS == "true" ]] ; then
-		einfo "Enabling cryptsetup USE flag"
-		echo 'USE="cryptsetup"' >> /etc/portage/make.conf \
-			|| die "Could not append to /etc/portage/make.conf"
-		einfo "Remerging @world with cryptsetup"
-		try emerge --verbose --changed-use --deep @world
+		einfo "Enabling cryptsetup USE flag on sys-apps/systemd"
+		echo "sys-apps/systemd cryptsetup" > /etc/portage/package.use/systemd \
+			|| die "Could not write /etc/portage/package.use/systemd"
+		einfo "Rebuilding systemd with changed USE flag"
+		try emerge --verbose --changed-use --oneshot sys-apps/systemd
 	fi
 
 	# Install btrfs-progs if we used btrfs


### PR DESCRIPTION
This patch enables cryptsetup USE flag and rebuilds `@world` if LUKS and systemd are both in use.

# Caveats
I'm not sure whether I'm doing this at the right installation stage, given earlier hooks could in theory have been used to set a USE flags in make.conf and this could break that.

I'm also not sure whether it would have been sufficient to only enable the USE flag for systemd and only rebuild that - I haven't tested anything more granular than `@world`, but I can if you like.

# The bug
I built a system with the simple partitioning scheme, encryption enabled and the systemd stage3 tarball.

The installation appeared to go fine, but boot failed finding the generated `cryptsetup@xxx.service` that refers to the luks volume.  Here's a screenshot:

![VirtualBox_gentoo-encrypted-bios-dev_26_03_2023_14_15_16](https://user-images.githubusercontent.com/398699/227792154-e1072034-50d1-43a2-ac9f-615996835adc.png)


I queried the use flags for `systemd` and it showed that it has a `cryptsetup` flag that needs to be set to enable it to unlock LUKS volumes.

See `equery uses sys-apps/systemd`

I managed to fix this manually after installation by chrooting in with `./install --chroot /tmp/gentoo-install/root` then:
- set `USE="cryptsetup"` in /etc/portage/make.conf`
- `emerge --jobs=3 --load-average=2.5 --ask --verbose --changed-use --deep @world`
  - this rebuilt systemd, util-linux and some dependencies
- `/boot/bios/generate_initramfs.sh 6.1.19-gentoo-dist /boot/bios/initramfs.img`
