### PR TITLE
feat: add raid1 support

### DIFF
--- a/configure
+++ b/configure
@@ -1168,7 +1168,7 @@ function PARTITIONING_DEVICES_label() {
 
 	if [[ "$invalid" -gt 0 ]]; then
 		echo " └ (${#PARTITIONING_DEVICES[@]} devices, \Z1$invalid invalid\Zn)"
-	elif [[ "${#PARTITIONING_DEVICES[@]}" -eq 1 && "$PARTITIONING_SCHEME" == "raid0_luks" || "$PARTITIONING_SCHEME" == "raid1_luks" ]]; then
+	elif [[ "${#PARTITIONING_DEVICES[@]}" -eq 1 && ("$PARTITIONING_SCHEME" == "raid0_luks" || "$PARTITIONING_SCHEME" == "raid1_luks") ]]; then
 		echo " └ (${#PARTITIONING_DEVICES[@]} devices, \Z1need at least 2\Zn)"
 	elif [[ "${#PARTITIONING_DEVICES[@]}" -eq 0 ]]; then
 		echo " └ (${#PARTITIONING_DEVICES[@]} devices, \Z1need at least 1\Zn)"

--- a/configure
+++ b/configure
@@ -169,6 +169,7 @@ function define_disk_layout() {
 		"zfs_centric")         define_disk_configuration_function "create_zfs_centric_layout swap=$(define_swap) type=${PARTITIONING_BOOT_TYPE@Q} encrypt=${PARTITIONING_ZFS_USE_ENCRYPTION@Q} compress=$(define_zfs_compression) pool_type=${PARTITIONING_ZFS_POOL_TYPE@Q}" "${PARTITIONING_DEVICES[@]@Q}" ;;
 		"btrfs_centric")       define_disk_configuration_function "create_btrfs_centric_layout swap=$(define_swap) type=${PARTITIONING_BOOT_TYPE@Q} raid_type=${PARTITIONING_BTRFS_RAID_TYPE@Q} luks=${PARTITIONING_USE_LUKS@Q}" "${PARTITIONING_DEVICES[@]@Q}" ;;
 		"raid0_luks")          define_disk_configuration_function "create_raid0_luks_layout swap=$(define_swap) type=${PARTITIONING_BOOT_TYPE@Q} root_fs=${PARTITIONING_ROOT_FS@Q}" "${PARTITIONING_DEVICES[@]@Q}" ;;
+		"raid1_luks")          define_disk_configuration_function "create_raid1_luks_layout swap=$(define_swap) type=${PARTITIONING_BOOT_TYPE@Q} root_fs=${PARTITIONING_ROOT_FS@Q}" "${PARTITIONING_DEVICES[@]@Q}" ;;
 		"custom")
 			# Show current function declaration, trim trailing whitespace
 			declare -f disk_configuration \
@@ -208,6 +209,7 @@ ALL_PARTITIONING_SCHEMES=(
 	"zfs_centric"         "ZFS centric (optional ZFS compression and encryption)"
 	"btrfs_centric"       "Btrfs centric (optional raid0/1 via btrfs)"
 	"raid0_luks"          "Raid0 (N>=2 disks) and luks for root"
+	"raid1_luks"          "Raid1 (N>=2 disks) and luks for root"
 	"custom"              "Custom (expert option; edit the config manually later)"
 )
 
@@ -281,6 +283,19 @@ function create_existing_partitions_layout() {
 
 function create_raid0_luks_layout() {
 	PARTITIONING_SCHEME="raid0_luks"
+
+	local known_arguments=('+swap' '?type' '?root_fs')
+	local extra_arguments=()
+	declare -A arguments; parse_arguments "$@"
+
+	PARTITIONING_DEVICES=("${extra_arguments[@]}")
+	parse_swap "${arguments[swap]}"
+	PARTITIONING_BOOT_TYPE="${arguments[type]}"
+	PARTITIONING_ROOT_FS="${arguments[root_fs]:-ext4}"
+}
+
+function create_raid1_luks_layout() {
+	PARTITIONING_SCHEME="raid1_luks"
 
 	local known_arguments=('+swap' '?type' '?root_fs')
 	local extra_arguments=()
@@ -905,6 +920,7 @@ function PARTITIONING_SCHEME_menu()  {
 			"zfs_centric")         create_zfs_centric_layout swap=8GiB type="$DEFAULT_BOOT_TYPE" encrypt=true compress=zstd pool_type=standard /dev/sdX ;;
 			"btrfs_centric")       create_btrfs_centric_layout swap=8GiB type="$DEFAULT_BOOT_TYPE" raid_type=raid0 luks=false /dev/sdX ;;
 			"raid0_luks")          create_raid0_luks_layout swap=8GiB type="$DEFAULT_BOOT_TYPE" root_fs=ext4 /dev/sdX /dev/sdY ;;
+			"raid1_luks")          create_raid1_luks_layout swap=8GiB type="$DEFAULT_BOOT_TYPE" root_fs=ext4 /dev/sdX /dev/sdY ;;
 			"custom")              PARTITIONING_SCHEME="$dialog_out" ;;
 		esac
 		UNSAVED_CHANGES=true
@@ -1012,7 +1028,7 @@ function PARTITIONING_SWAP_DEVICE_menu()  {
 
 function PARTITIONING_ROOT_FS_tag()   { echo " ├ Root filesystem"; }
 function PARTITIONING_ROOT_FS_label() { echo " ├ ($PARTITIONING_ROOT_FS)"; }
-function PARTITIONING_ROOT_FS_show()  { [[ $PARTITIONING_SCHEME != "custom" ]] && one_of "$PARTITIONING_SCHEME" "classic_single_disk" "raid0_luks"; }
+function PARTITIONING_ROOT_FS_show()  { [[ $PARTITIONING_SCHEME != "custom" ]] && one_of "$PARTITIONING_SCHEME" "classic_single_disk" "raid0_luks" "raid1_luks"; }
 function PARTITIONING_ROOT_FS_help()  { echo "Select the amount of swap to use."; }
 function PARTITIONING_ROOT_FS_menu()  {
 	if menu_radiolist \
@@ -1152,7 +1168,7 @@ function PARTITIONING_DEVICES_label() {
 
 	if [[ "$invalid" -gt 0 ]]; then
 		echo " └ (${#PARTITIONING_DEVICES[@]} devices, \Z1$invalid invalid\Zn)"
-	elif [[ "${#PARTITIONING_DEVICES[@]}" -eq 1 && "$PARTITIONING_SCHEME" == "raid0_luks" ]]; then
+	elif [[ "${#PARTITIONING_DEVICES[@]}" -eq 1 && "$PARTITIONING_SCHEME" == "raid0_luks" || "$PARTITIONING_SCHEME" == "raid1_luks" ]]; then
 		echo " └ (${#PARTITIONING_DEVICES[@]} devices, \Z1need at least 2\Zn)"
 	elif [[ "${#PARTITIONING_DEVICES[@]}" -eq 0 ]]; then
 		echo " └ (${#PARTITIONING_DEVICES[@]} devices, \Z1need at least 1\Zn)"
@@ -1160,7 +1176,7 @@ function PARTITIONING_DEVICES_label() {
 		echo " └ (${#PARTITIONING_DEVICES[@]} devices)"
 	fi
 }
-function PARTITIONING_DEVICES_show()  { [[ $PARTITIONING_SCHEME != "custom" ]] && one_of "$PARTITIONING_SCHEME" "raid0_luks" "zfs_centric" "btrfs_centric"; }
+function PARTITIONING_DEVICES_show()  { [[ $PARTITIONING_SCHEME != "custom" ]] && one_of "$PARTITIONING_SCHEME" "raid0_luks" "raid1_luks" "zfs_centric" "btrfs_centric"; }
 function PARTITIONING_DEVICES_help()  { echo "The block devices to which the layout will be applied."; }
 function PARTITIONING_DEVICES_menu()  {
 	local invalid=()

--- a/gentoo.conf.example
+++ b/gentoo.conf.example
@@ -74,7 +74,22 @@ function disk_configuration() {
 	# Careful: You will get N times the swap amount, so be sure to divide beforehand.
 	#create_raid0_luks_layout swap=4GiB type=efi root_fs=ext4 /dev/sd{X,Y}
 
-	# 4. create_btrfs_centric_layout
+	# 4. create_raid1_luks_layout
+	#
+	# This layout creates the single disk layout on multiple disks and combines
+	# the swap and root partitions in separate raid1 arrays. Useful if you e.g. have
+	# several nvme drives and want data redundancy. Only one boot partition will actually
+	# be used though.
+	#
+	# Parameters:
+	#   swap=<size>           Create a swap partition with given size for each disk,
+	#                         or no swap at all if set to false
+	#   type=[efi|bios]       Selects the boot type. Defaults to efi if not given.
+	#   root_fs=[ext4|btrfs]  Root filesystem
+	# Careful: You will get N times the swap amount, so be sure to divide beforehand.
+	#create_raid1_luks_layout swap=4GiB type=efi root_fs=ext4 /dev/sd{X,Y}
+
+	# 5. create_btrfs_centric_layout
 	#
 	# This layout is the same as the single_disk_layout, but uses btrfs as the root
 	# filesystem and allows you to put additional disks into the btrfs device pool.

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -311,7 +311,7 @@ function create_classic_single_disk_layout() {
 	local root_fs="${arguments[root_fs]:-ext4}"
 
 	create_gpt new_id=gpt device="$device"
-	create_partition new_id="part_$type" id=gpt size=512MiB       type="$type"
+	create_partition new_id="part_$type" id=gpt size=1GiB       type="$type"
 	[[ $size_swap != "false" ]] \
 		&& create_partition new_id=part_swap    id=gpt size="$size_swap" type=swap
 	create_partition new_id=part_root    id=gpt size=remaining    type=linux
@@ -408,7 +408,7 @@ function create_zfs_centric_layout() {
 
 	# Create layout on first disk
 	create_gpt new_id="gpt_dev0" device="${extra_arguments[0]}"
-	create_partition new_id="part_${type}_dev0" id="gpt_dev0" size=512MiB       type="$type"
+	create_partition new_id="part_${type}_dev0" id="gpt_dev0" size=1GiB       type="$type"
 	[[ $size_swap != "false" ]] \
 		&& create_partition new_id="part_swap_dev0"    id="gpt_dev0" size="$size_swap" type=swap
 	create_partition new_id="part_root_dev0"    id="gpt_dev0" size=remaining    type=linux
@@ -460,7 +460,7 @@ function create_raid0_luks_layout() {
 
 	for i in "${!extra_arguments[@]}"; do
 		create_gpt new_id="gpt_dev${i}" device="${extra_arguments[$i]}"
-		create_partition new_id="part_${type}_dev${i}" id="gpt_dev${i}" size=512MiB       type="$type"
+		create_partition new_id="part_${type}_dev${i}" id="gpt_dev${i}" size=1GiB       type="$type"
 		[[ $size_swap != "false" ]] \
 			&& create_partition new_id="part_swap_dev${i}"    id="gpt_dev${i}" size="$size_swap" type=raid
 		create_partition new_id="part_root_dev${i}"    id="gpt_dev${i}" size=remaining    type=raid
@@ -517,7 +517,7 @@ function create_raid1_luks_layout() {
 
 	for i in "${!extra_arguments[@]}"; do
 		create_gpt new_id="gpt_dev${i}" device="${extra_arguments[$i]}"
-		create_partition new_id="part_${type}_dev${i}" id="gpt_dev${i}" size=512MiB       type="$type"
+		create_partition new_id="part_${type}_dev${i}" id="gpt_dev${i}" size=1GiB       type="$type"
 		[[ $size_swap != "false" ]] \
 			&& create_partition new_id="part_swap_dev${i}"    id="gpt_dev${i}" size="$size_swap" type=raid
 		create_partition new_id="part_root_dev${i}"    id="gpt_dev${i}" size=remaining    type=raid
@@ -575,7 +575,7 @@ function create_btrfs_centric_layout() {
 
 	# Create layout on first disk
 	create_gpt new_id="gpt_dev0" device="${extra_arguments[0]}"
-	create_partition new_id="part_${type}_dev0" id="gpt_dev0" size=512MiB       type="$type"
+	create_partition new_id="part_${type}_dev0" id="gpt_dev0" size=1GiB       type="$type"
 	[[ $size_swap != "false" ]] \
 		&& create_partition new_id="part_swap_dev0"    id="gpt_dev0" size="$size_swap" type=swap
 	create_partition new_id="part_root_dev0"    id="gpt_dev0" size=remaining    type=linux

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -311,7 +311,7 @@ function create_classic_single_disk_layout() {
 	local root_fs="${arguments[root_fs]:-ext4}"
 
 	create_gpt new_id=gpt device="$device"
-	create_partition new_id="part_$type" id=gpt size=1GiB       type="$type"
+	create_partition new_id="part_$type" id=gpt size=512MiB       type="$type"
 	[[ $size_swap != "false" ]] \
 		&& create_partition new_id=part_swap    id=gpt size="$size_swap" type=swap
 	create_partition new_id=part_root    id=gpt size=remaining    type=linux
@@ -408,7 +408,7 @@ function create_zfs_centric_layout() {
 
 	# Create layout on first disk
 	create_gpt new_id="gpt_dev0" device="${extra_arguments[0]}"
-	create_partition new_id="part_${type}_dev0" id="gpt_dev0" size=1GiB       type="$type"
+	create_partition new_id="part_${type}_dev0" id="gpt_dev0" size=512MiB       type="$type"
 	[[ $size_swap != "false" ]] \
 		&& create_partition new_id="part_swap_dev0"    id="gpt_dev0" size="$size_swap" type=swap
 	create_partition new_id="part_root_dev0"    id="gpt_dev0" size=remaining    type=linux
@@ -460,7 +460,7 @@ function create_raid0_luks_layout() {
 
 	for i in "${!extra_arguments[@]}"; do
 		create_gpt new_id="gpt_dev${i}" device="${extra_arguments[$i]}"
-		create_partition new_id="part_${type}_dev${i}" id="gpt_dev${i}" size=1GiB       type="$type"
+		create_partition new_id="part_${type}_dev${i}" id="gpt_dev${i}" size=512MiB       type="$type"
 		[[ $size_swap != "false" ]] \
 			&& create_partition new_id="part_swap_dev${i}"    id="gpt_dev${i}" size="$size_swap" type=raid
 		create_partition new_id="part_root_dev${i}"    id="gpt_dev${i}" size=remaining    type=raid
@@ -517,7 +517,7 @@ function create_raid1_luks_layout() {
 
 	for i in "${!extra_arguments[@]}"; do
 		create_gpt new_id="gpt_dev${i}" device="${extra_arguments[$i]}"
-		create_partition new_id="part_${type}_dev${i}" id="gpt_dev${i}" size=1GiB       type="$type"
+		create_partition new_id="part_${type}_dev${i}" id="gpt_dev${i}" size=512MiB       type="$type"
 		[[ $size_swap != "false" ]] \
 			&& create_partition new_id="part_swap_dev${i}"    id="gpt_dev${i}" size="$size_swap" type=raid
 		create_partition new_id="part_root_dev${i}"    id="gpt_dev${i}" size=remaining    type=raid
@@ -575,7 +575,7 @@ function create_btrfs_centric_layout() {
 
 	# Create layout on first disk
 	create_gpt new_id="gpt_dev0" device="${extra_arguments[0]}"
-	create_partition new_id="part_${type}_dev0" id="gpt_dev0" size=1GiB       type="$type"
+	create_partition new_id="part_${type}_dev0" id="gpt_dev0" size=512MiB       type="$type"
 	[[ $size_swap != "false" ]] \
 		&& create_partition new_id="part_swap_dev0"    id="gpt_dev0" size="$size_swap" type=swap
 	create_partition new_id="part_root_dev0"    id="gpt_dev0" size=remaining    type=linux

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -276,6 +276,7 @@ function disk_create_raid() {
 
 	local devices_desc=""
 	local devices=()
+	local extra_args=()
 	local id
 	local dev
 	# Splitting is intentional here
@@ -291,31 +292,24 @@ function disk_create_raid() {
 	local mddevice="/dev/md/$name"
 	local uuid="${DISK_ID_TO_UUID[$new_id]}"
 
+	extra_args=()
 	if [[ ${level} == 1 ]]; then
-		einfo "Creating raid$level ($new_id) on $devices_desc"
-		mdadm \
-				--create "$mddevice" \
-				--verbose \
-				--homehost="$HOSTNAME" \
-				--metadata=1.0 \
-				--raid-devices="${#devices[@]}" \
-				--uuid="$uuid" \
-				--level="$level" \
-				"${devices[@]}" \
-			|| die "Could not create raid$level array '$mddevice' ($new_id) on $devices_desc"
+		extra_args+=("--metadata=1.0")
 	else
-		einfo "Creating raid$level ($new_id) on $devices_desc"
-		mdadm \
-				--create "$mddevice" \
-				--verbose \
-				--homehost="$HOSTNAME" \
-				--metadata=1.2 \
-				--raid-devices="${#devices[@]}" \
-				--uuid="$uuid" \
-				--level="$level" \
-				"${devices[@]}" \
-			|| die "Could not create raid$level array '$mddevice' ($new_id) on $devices_desc"
+		extra_args+=("--metadata=1.2")
 	fi
+
+	einfo "Creating raid$level ($new_id) on $devices_desc"
+	mdadm \
+			--create "$mddevice" \
+			--verbose \
+			--homehost="$HOSTNAME" \
+			"${extra_args[@]}" \
+			--raid-devices="${#devices[@]}" \
+			--uuid="$uuid" \
+			--level="$level" \
+			"${devices[@]}" \
+		|| die "Could not create raid$level array '$mddevice' ($new_id) on $devices_desc"
 }
 
 function disk_create_luks() {

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -291,17 +291,31 @@ function disk_create_raid() {
 	local mddevice="/dev/md/$name"
 	local uuid="${DISK_ID_TO_UUID[$new_id]}"
 
-	einfo "Creating raid$level ($new_id) on $devices_desc"
-	mdadm \
-			--create "$mddevice" \
-			--verbose \
-			--homehost="$HOSTNAME" \
-			--metadata=1.2 \
-			--raid-devices="${#devices[@]}" \
-			--uuid="$uuid" \
-			--level="$level" \
-			"${devices[@]}" \
-		|| die "Could not create raid$level array '$mddevice' ($new_id) on $devices_desc"
+	if [[ ${level} == 1 ]]; then
+		einfo "Creating raid$level ($new_id) on $devices_desc"
+		mdadm \
+				--create "$mddevice" \
+				--verbose \
+				--homehost="$HOSTNAME" \
+				--metadata=1.0 \
+				--raid-devices="${#devices[@]}" \
+				--uuid="$uuid" \
+				--level="$level" \
+				"${devices[@]}" \
+			|| die "Could not create raid$level array '$mddevice' ($new_id) on $devices_desc"
+	else
+		einfo "Creating raid$level ($new_id) on $devices_desc"
+		mdadm \
+				--create "$mddevice" \
+				--verbose \
+				--homehost="$HOSTNAME" \
+				--metadata=1.2 \
+				--raid-devices="${#devices[@]}" \
+				--uuid="$uuid" \
+				--level="$level" \
+				"${devices[@]}" \
+			|| die "Could not create raid$level array '$mddevice' ($new_id) on $devices_desc"
+	fi
 }
 
 function disk_create_luks() {

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -276,7 +276,6 @@ function disk_create_raid() {
 
 	local devices_desc=""
 	local devices=()
-	local extra_args=()
 	local id
 	local dev
 	# Splitting is intentional here


### PR DESCRIPTION
@oddlama Hey, could you please check this one for me, especially if you can simplify the code.

The only important thing in the case of a raid1 is to set `--metadata=1.0` on the MD for the superblock to be stored at the end of the RAID partition to give the UEFI firmware the ability to detect the ESP.

Thank you in advance for your feedback.