### PR TITLE
fix: "error: format: Identifier id='part_root' not found"

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -472,7 +472,7 @@ function create_raid0_luks_layout() {
 		&& create_raid new_id=part_raid_swap name="swap" level=0 ids="$(expand_ids '^part_swap_dev[[:digit:]]$')"
 	create_raid new_id=part_raid_root name="root" level=0 ids="$(expand_ids '^part_root_dev[[:digit:]]$')"
 
-	local root_id="part_root"
+	local root_id="part_raid_root"
 	if [[ "$use_luks" == "true" ]]; then
 		create_luks new_id=part_luks_root name="root" id=part_raid_root
 		root_id="part_luks_root"
@@ -536,7 +536,7 @@ function create_raid1_luks_layout() {
 		&& create_raid new_id=part_raid_swap name="swap" level=1 ids="$(expand_ids '^part_swap_dev[[:digit:]]$')"
 	create_raid new_id=part_raid_root name="root" level=1 ids="$(expand_ids '^part_root_dev[[:digit:]]$')"
 
-	local root_id="part_root"
+	local root_id="part_raid_root"
 	if [[ "$use_luks" == "true" ]]; then
 		create_luks new_id=part_luks_root name="root" id=part_raid_root
 		root_id="part_luks_root"


### PR DESCRIPTION
This commit fixes the installer not working in both `create_raid0_luks_layout()` and `create_raid1_luks_layout()`.

Seems like I have overlooked it.