### PR TITLE
fix: musl stage3 installation on the stable branch

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -15,6 +15,9 @@ function install_stage3() {
 function configure_base_system() {
 	if [[ $MUSL == "true" ]]; then
 		einfo "Installing musl-locales"
+		if [[ $USE_PORTAGE_TESTING == "false" ]]; then
+			echo "sys-apps/musl-locales" >> /etc/portage/package.accept_keywords/musl-locales
+		fi
 		try emerge --verbose sys-apps/musl-locales
 	else
 		einfo "Generating locales"


### PR DESCRIPTION
This commit fixes this error:
```bash
!!! All ebuilds that could satisfy "sys-apps/musl-locales" have been masked.
!!! One of the following masked packages is required to complete your request:
- sys-apps/musl-locales-0.1.0::gentoo (masked by: ~amd64 keyword)

For more information, see the MASKED PACKAGES section in the emerge
man page or refer to the Gentoo Handbook.

 * Command failed: $ emerge --verbose sys-apps/musl-locales
Last command failed with exit code 1
```