### PR TITLE
fix: use 00local instead of 00musl

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -60,8 +60,8 @@ function configure_base_system() {
 		if [[ $MUSL == "true" ]]; then
 			try emerge -v sys-libs/timezone-data
 			einfo "Selecting timezone"
-			echo -e "\nTZ=\"$TIMEZONE\"" >> /etc/env.d/00musl \
-				|| die "Could not write to /etc/env.d/00musl"
+			echo -e "\nTZ=\"$TIMEZONE\"" >> /etc/env.d/00local \
+				|| die "Could not write to /etc/env.d/00local"
 		else
 			einfo "Selecting timezone"
 			echo "$TIMEZONE" > /etc/timezone \


### PR DESCRIPTION
This commit replaces 00musl with 00local to prevent the file from being overwritten when the musl package is rebuilt.

For further details, see: https://wiki.gentoo.org/index.php?title=Musl_usage_guide&diff=1310555&oldid=1303905