### PR TITLE
fix: update musl-locales installation process

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -15,7 +15,7 @@ function install_stage3() {
 function configure_base_system() {
 	if [[ $MUSL == "true" ]]; then
 		einfo "Installing musl-locales"
-		if [[ $USE_PORTAGE_TESTING == "false" ]]; then
+		if [[ $USE_PORTAGE_TESTING == "false" && $GENTOO_ARCH == "i686" ]]; then
 			echo "sys-apps/musl-locales" >> /etc/portage/package.accept_keywords/musl-locales
 		fi
 		try emerge --verbose sys-apps/musl-locales


### PR DESCRIPTION
The `sys-apps/musl-locales` package has been stabilized on amd64, arm, arm64, and ppc64 architectures.

gentoo-install supports only x86, amd64, arm, and arm64: https://github.com/oddlama/gentoo-install/blob/40d038668bfb5c157585c1841762da3dd3d3ca0e/configure#L181

For further details, see: https://packages.gentoo.org/packages/sys-apps/musl-locales