### PR TITLE
feat: add x86 sub-architecture selection

### DIFF
--- a/configure
+++ b/configure
@@ -1476,7 +1476,21 @@ function GENTOO_ARCH_menu()  {
 		"$GENTOO_ARCH" \
 		"${ALL_GENTOO_ARCHS[@]}"
 	then
-		GENTOO_ARCH="$dialog_out"
+		if [[ "$dialog_out" == "x86" ]]; then
+			local sub_archs=("i486" "i686")
+			if menu_radiolist \
+				"Select x86 sub-architecture" \
+				"Select the specific sub-architecture for x86." \
+				"${sub_archs[0]}" \
+				"${sub_archs[@]}"
+			then
+				GENTOO_ARCH="$dialog_out"
+			else
+				GENTOO_ARCH="${sub_archs[0]}"
+			fi
+		else
+			GENTOO_ARCH="$dialog_out"
+		fi
 		UNSAVED_CHANGES=true
 	else
 		# Return to menu

--- a/configure
+++ b/configure
@@ -1486,7 +1486,7 @@ function GENTOO_ARCH_menu()  {
 			then
 				GENTOO_ARCH="$dialog_out"
 			else
-				GENTOO_ARCH="${sub_archs[0]}"
+				return 1
 			fi
 		else
 			GENTOO_ARCH="$dialog_out"


### PR DESCRIPTION
@oddlama,

I missed this subtle detail in my last commit.

Could you review it and suggest if there's a better way to implement it?

As shown here: [Gentoo Downloads (x86)](https://www.gentoo.org/downloads/#x86), the URL is either **stage3-i486** or **stage3-i686**.

Thanks!