### PR TITLE
use chrony and curl as fallback to sync time

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -7,7 +7,15 @@ source "$GENTOO_INSTALL_REPO_DIR/scripts/protection.sh" || exit 1
 
 function sync_time() {
 	einfo "Syncing time"
-	try ntpd -g -q
+	if command -v ntpd &> /dev/null; then
+		try ntpd -g -q
+	elif command -v chrony &> /dev/null; then
+		# See https://github.com/oddlama/gentoo-install/pull/122
+		try chronyd -q
+	else
+		# why am I doing this?
+		try date -s "$(curl -sI http://example.com | grep -i ^date: | cut -d' ' -f3-)"
+	fi
 
 	einfo "Current date: $(LANG=C date)"
 	einfo "Writing time to hardware clock"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -452,6 +452,8 @@ function check_wanted_programs() {
 				fi
 			done
 		fi
+	elif type curl &>/dev/null; then
+		:
 	else
 		if [[ "${#missing_required[@]}" -gt 0 ]]; then
 			die "Aborted installer because of missing required programs."


### PR DESCRIPTION
See #122 

Adds a fallback for time synchronization.
Sets the time manually using curl if `ntpd` & `chrony` are unavailable
