### PR TITLE
fix: enhance security and enforce signature verification

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -105,9 +105,11 @@ function configure_portage() {
 	fi
 
 	if [[ $ENABLE_BINPKG == "true" ]]; then
-		echo 'FEATURES="getbinpkg"' >> /etc/portage/make.conf
-  		getuto
-    		chmod 644 /etc/portage/gnupg/pubring.kbx
+		echo 'FEATURES="getbinpkg binpkg-request-signature"' >> /etc/portage/make.conf
+		getuto
+		chown -R root:root /etc/portage/gnupg
+		chmod 700 /etc/portage/gnupg
+		chmod 600 /etc/portage/gnupg/*
 	fi
 
 	chmod 644 /etc/portage/make.conf \


### PR DESCRIPTION
| Aspect | v1 | v2 | Reason v2 is better |
|-|-|-|-|
| Signature Verification | Only includes getbinpkg, allowing unsigned binary packages. | Includes binpkg-request-signature, enforcing binary package signing and verification. | v2 ensures only signed packages are installed, protecting against malicious or tampered packages. |
| GPG Key Permissions | Sets pubring.kbx permissions to 644, making it world-readable. | Sets directory permissions to 700 and file permissions to 600 for GPG keys. | v2 ensures secure management of GPG keys, protecting against unauthorized access or tampering. |
| Security of Package Installation | Allows installation of unsigned packages, exposing to security risks. | Rejects unsigned binary packages, preventing unverified installs. | v2 strengthens package integrity and ensures only verified packages are installed, safeguarding the system. |

### Conclusion

- **v1** lacks these protections, leaving us vulnerable to unsigned packages and improper key management.
- **v2** enforces stronger security through signature verification and proper GPG key management.

Using **v2** is the more secure choice for a production environment.
