### PR TITLE
fix: revert to old code and keep signature verification

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -107,9 +107,7 @@ function configure_portage() {
 	if [[ $ENABLE_BINPKG == "true" ]]; then
 		echo 'FEATURES="getbinpkg binpkg-request-signature"' >> /etc/portage/make.conf
 		getuto
-		chown -R root:root /etc/portage/gnupg
-		chmod 700 /etc/portage/gnupg
-		chmod 600 /etc/portage/gnupg/*
+		chmod 644 /etc/portage/gnupg/pubring.kbx
 	fi
 
 	chmod 644 /etc/portage/make.conf \


### PR DESCRIPTION
The fix has been tested on a VM and addresses the following errors:
```sh
gpg: WARNING: unsafe ownership on homedir '/etc/portage/gnupg'
gpg: failed to create temporary file '/etc/portage/gnupg/.#lk0x58b3b260.archiso.23516': Permission denied
gpg: keyblock resource '/etc/portage/gnupg/pubrink.kbx': Permission denied
```