### PR TITLE
chore: remove unnecessary check

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -15,9 +15,6 @@ function install_stage3() {
 function configure_base_system() {
 	if [[ $MUSL == "true" ]]; then
 		einfo "Installing musl-locales"
-		if [[ $USE_PORTAGE_TESTING == "false" && $GENTOO_ARCH == "i686" ]]; then
-			echo "sys-apps/musl-locales" >> /etc/portage/package.accept_keywords/musl-locales
-		fi
 		try emerge --verbose sys-apps/musl-locales
 	else
 		einfo "Generating locales"


### PR DESCRIPTION
This is a follow-up to [PR #125](https://github.com/oddlama/gentoo-install/pull/125).

Since the `sys-apps/musl-locales` package has now been stabilized on the x86 architecture, the previous check is no longer needed and has been removed.