### PR TITLE
fix: minor typos

### DIFF
--- a/gentoo.conf.example
+++ b/gentoo.conf.example
@@ -41,7 +41,7 @@ function disk_configuration() {
 	#   root_fs=[ext4|btrfs]  Root filesystem. Defaults to ext4 if not given.
 	#create_classic_single_disk_layout swap=8GiB type=efi luks=true root_fs=ext4 /dev/sdX
 
-	# 2. create_btrfs_centric_layout
+	# 2. create_zfs_centric_layout
 	#
 	# A modern disk layout designed around ZFS. This layout is the same as the
 	# single_disk_layout, but uses ZFS as the root filesystem and optionally allows
@@ -51,12 +51,12 @@ function disk_configuration() {
 	# encryption feature to encrypt the pool.
 	#
 	# Parameters:
-	#   swap=<size>                Create a swap partition with given size, or no swap
-	#                              at all if set to false.
-	#   type=[efi|bios]            Selects the boot type. Defaults to efi if not given.
-	#   encrypt=[true|false]       Encrypt the zfs datasets. Defaults to false if not given.
-	#   compress=[false|<compression>] Compress the zfs datasets. For valid values visit man zfsprops. Defaults to false if not given.
-	#   pool_type=[standard|custom]  Select zfs pool type. Custom pools allow you to do the pool creation yourself. Defaults to standard.
+	#   swap=<size>                     Create a swap partition with given size, or no swap
+	#                                   at all if set to false.
+	#   type=[efi|bios]                 Selects the boot type. Defaults to efi if not given.
+	#   encrypt=[true|false]            Encrypt the zfs datasets. Defaults to false if not given.
+	#   compress=[false|<compression>]  Compress the zfs datasets. For valid values visit man zfsprops. Defaults to false if not given.
+	#   pool_type=[standard|custom]     Select zfs pool type. Custom pools allow you to do the pool creation yourself. Defaults to standard.
 	#create_zfs_centric_layout type=efi swap=8GiB encrypt=true compress=zstd pool_type=standard
 
 	# 3. create_raid0_luks_layout
@@ -101,12 +101,12 @@ function disk_configuration() {
 	# Also works with a single device.
 	#
 	# Parameters:
-	#   swap=<size>                Create a swap partition with given size, or no swap
-	#                              at all if set to false.
-	#   type=[efi|bios]            Selects the boot type. Defaults to efi if not given.
-	#   luks=[true|false]          Encrypt root partition and btrfs devices. Defaults
-	#                              to false if not given.
-	#   raid_type=[raid0|raid1]    Select raid type. Defaults to raid0.
+	#   swap=<size>              Create a swap partition with given size, or no swap
+	#                            at all if set to false.
+	#   type=[efi|bios]          Selects the boot type. Defaults to efi if not given.
+	#   luks=[true|false]        Encrypt root partition and btrfs devices. Defaults
+	#                            to false if not given.
+	#   raid_type=[raid0|raid1]  Select raid type. Defaults to raid0.
 	#create_btrfs_centric_layout swap=8GiB luks=false raid_type=raid0 /dev/sd{X,Y}
 	#create_btrfs_centric_layout swap=8GiB luks=true /dev/sdX
 }

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -389,12 +389,13 @@ function create_existing_partitions_layout() {
 # Multiple disks, up to 3 partitions on first disk (efi, optional swap, root with zfs).
 # Additional devices will be added to the zfs pool.
 # Parameters:
-#   swap=<size>                Create a swap partition with given size, or no swap at all if set to false.
-#   type=[efi|bios]            Selects the boot type. Defaults to efi if not given.
-#   encrypt=[true|false]       Encrypt zfs pool. Defaults to false if not given.
-#   pool_type=[stripe|mirror]  Select raid type. Defaults to stripe.
+#   swap=<size>                     Create a swap partition with given size, or no swap at all if set to false.
+#   type=[efi|bios]                 Selects the boot type. Defaults to efi if not given.
+#   encrypt=[true|false]            Encrypt the zfs datasets. Defaults to false if not given.
+#   compress=[false|<compression>]  Compress the zfs datasets. For valid values visit man zfsprops. Defaults to false if not given.
+#   pool_type=[standard|custom]     Select zfs pool type. Custom pools allow you to do the pool creation yourself. Defaults to standard.
 function create_zfs_centric_layout() {
-	local known_arguments=('+swap' '?type' '?pool_type' '?encrypt' '?compress')
+	local known_arguments=('+swap' '?type' '?encrypt' '?compress' '?pool_type')
 	local extra_arguments=()
 	declare -A arguments; parse_arguments "$@"
 
@@ -402,9 +403,9 @@ function create_zfs_centric_layout() {
 		|| die_trace 1 "Expected at least one positional argument (the devices)"
 	local device="${extra_arguments[0]}"
 	local size_swap="${arguments[swap]}"
-	local pool_type="${arguments[pool_type]:-stripe}"
 	local type="${arguments[type]:-efi}"
 	local encrypt="${arguments[encrypt]:-false}"
+	local pool_type="${arguments[pool_type]:-standard}"
 
 	# Create layout on first disk
 	create_gpt new_id="gpt_dev0" device="${extra_arguments[0]}"
@@ -575,7 +576,7 @@ function create_raid1_luks_layout() {
 #   luks=[true|false]          Encrypt root partition and btrfs devices. Defaults to false if not given.
 #   raid_type=[raid0|raid1]    Select raid type. Defaults to raid0.
 function create_btrfs_centric_layout() {
-	local known_arguments=('+swap' '?type' '?raid_type' '?luks')
+	local known_arguments=('+swap' '?type' '?luks' '?raid_type')
 	local extra_arguments=()
 	declare -A arguments; parse_arguments "$@"
 
@@ -583,9 +584,9 @@ function create_btrfs_centric_layout() {
 		|| die_trace 1 "Expected at least one positional argument (the devices)"
 	local device="${extra_arguments[0]}"
 	local size_swap="${arguments[swap]}"
-	local raid_type="${arguments[raid_type]:-raid0}"
 	local type="${arguments[type]:-efi}"
 	local use_luks="${arguments[luks]:-false}"
+	local raid_type="${arguments[raid_type]:-raid0}"
 
 	# Create layout on first disk
 	create_gpt new_id="gpt_dev0" device="${extra_arguments[0]}"


### PR DESCRIPTION
Improvements over commit [a5cfe87](https://github.com/oddlama/gentoo-install/commit/a5cfe872a3ef597c9ec6fb41bd470c4b3b9168ee) and commit [99667b2](https://github.com/oddlama/gentoo-install/commit/99667b2cd2b3a6f4804d056eafddee8ed06d2794).