### PR TITLE
fix: improve RAID 1 implementation

### DIFF
--- a/gentoo.conf.example
+++ b/gentoo.conf.example
@@ -62,7 +62,7 @@ function disk_configuration() {
 	# 3. create_raid0_luks_layout
 	#
 	# This layout creates the single disk layout on multiple disks and combines
-	# the swap and root partitions in separate raid0 arrays. Useful if you e.g. have
+	# the swap and root partitions in separate RAID0 arrays. Useful if you e.g. have
 	# several nvme drives and want increased speed. Only one boot partition will actually
 	# be used though.
 	#
@@ -78,9 +78,9 @@ function disk_configuration() {
 	# 4. create_raid1_luks_layout
 	#
 	# This layout creates the single disk layout on multiple disks and combines
-	# the swap and root partitions in separate raid1 arrays. Useful if you e.g. have
-	# several nvme drives and want data redundancy. Only one boot partition will actually
-	# be used though.
+	# the boot, swap, and root partitions in separate RAID1 arrays. Useful if you e.g. have
+	# several nvme drives and want data redundancy. Each drive will have the boot partition mirrored.
+	# If one drive fails, the system can still boot from another drive in the array.
 	#
 	# Parameters:
 	#   swap=<size>           Create a swap partition with given size for each disk,

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -533,6 +533,7 @@ function create_raid1_luks_layout() {
 		create_partition new_id="part_root_dev${i}"    id="gpt_dev${i}" size=remaining    type=raid
 	done
 
+	create_raid new_id="part_raid_${type}" name="$type" level=1 ids="$(expand_ids "^part_${type}_dev[[:digit:]]$")"
 	[[ $size_swap != "false" ]] \
 		&& create_raid new_id=part_raid_swap name="swap" level=1 ids="$(expand_ids '^part_swap_dev[[:digit:]]$')"
 	create_raid new_id=part_raid_root name="root" level=1 ids="$(expand_ids '^part_root_dev[[:digit:]]$')"
@@ -543,15 +544,15 @@ function create_raid1_luks_layout() {
 		root_id="part_luks_root"
 	fi
 
-	format id="part_${type}_dev0" type="$type" label="$type"
+	format id="part_raid_${type}" type="$type" label="$type"
 	[[ $size_swap != "false" ]] \
 		&& format id=part_raid_swap type=swap label=swap
 	format id="$root_id" type="$root_fs" label=root
 
 	if [[ $type == "efi" ]]; then
-		DISK_ID_EFI="part_${type}_dev0"
+		DISK_ID_EFI="part_raid_${type}"
 	else
-		DISK_ID_BIOS="part_${type}_dev0"
+		DISK_ID_BIOS="part_raid_${type}"
 	fi
 	[[ $size_swap != "false" ]] \
 		&& DISK_ID_SWAP=part_raid_swap

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -505,7 +505,7 @@ function create_raid0_luks_layout() {
 }
 
 # Multiple disks, with raid 1 and luks
-# - efi:  partition on all disks, but only first disk used
+# - efi:  raid 1 → fs
 # - swap: raid 1 → fs
 # - root: raid 1 → luks → fs
 # Parameters:

--- a/scripts/dispatch_chroot.sh
+++ b/scripts/dispatch_chroot.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -uo pipefail
 
-
 [[ $EXECUTED_IN_CHROOT != "true" ]] \
 	&& { echo "This script must not be executed directly!" >&2; exit 1; }
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -300,21 +300,22 @@ function disk_create_raid() {
 	local uuid="${DISK_ID_TO_UUID[$new_id]}"
 
 	extra_args=()
-	if [[ ${level} == 1 ]]; then
+	if [[ "$level" == 1 && "$name" == "efi" ]]; then
 		extra_args+=("--metadata=1.0")
 	else
 		extra_args+=("--metadata=1.2")
 	fi
 
+# See https://serverfault.com/questions/1163715/mdadm-value-arch12021-cannot-be-set-as-devname-reason-not-posix-compatible
 	einfo "Creating raid$level ($new_id) on $devices_desc"
 	mdadm \
 			--create "$mddevice" \
 			--verbose \
-			--homehost="$HOSTNAME" \
-			"${extra_args[@]}" \
+			--level="$level" \
 			--raid-devices="${#devices[@]}" \
 			--uuid="$uuid" \
-			--level="$level" \
+			--homehost="$HOSTNAME" \
+			"${extra_args[@]}" \
 			"${devices[@]}" \
 		|| die "Could not create raid$level array '$mddevice' ($new_id) on $devices_desc"
 }

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -244,10 +244,6 @@ function install_kernel_efi() {
 		einfo "Assuming partition 1 for RAID-based EFI on device $efipartdev"
 	fi
 
-	einfo "DEBUG: sys_efipart = '$sys_efipart'"
-	einfo "DEBUG: efipartdev = '$efipartdev'"
-	einfo "DEBUG: efipartnum = '$efipartnum'"
-
 	# Identify the parent block device and create EFI boot entry
 	local gptdev
 	if mdadm --detail --scan "$efipartdev" | grep -qE "^ARRAY $efipartdev " && [[ "$efipartdev" =~ ^/dev/md[0-9]+$ ]]; then

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -172,6 +172,7 @@ function generate_initramfs() {
 		--zstd \
 		--no-hostonly \
 		--ro-mnt \
+		--mdadmconf \
 		--add           "bash ${modules[*]}" \
 		"${dracut_opts[@]}" \
 		--force \
@@ -188,6 +189,7 @@ dracut \\
 	--zstd \\
 	--no-hostonly \\
 	--ro-mnt \\
+	--mdadmconf \\
 	--add           "bash ${modules[*]}" \\
 	${dracut_opts[@]@Q} \\
 	--force \\
@@ -220,26 +222,60 @@ function install_kernel_efi() {
 	generate_initramfs "/boot/efi/initramfs.img"
 
 	# Create boot entry
-	einfo "Creating efi boot entry"
+	einfo "Creating EFI boot entry"
 	local efipartdev
 	efipartdev="$(resolve_device_by_id "$DISK_ID_EFI")" \
 		|| die "Could not resolve device with id=$DISK_ID_EFI"
 	efipartdev="$(realpath "$efipartdev")" \
 		|| die "Error in realpath '$efipartdev'"
+
+	# Get the sysfs path to EFI partition
 	local sys_efipart
 	sys_efipart="/sys/class/block/$(basename "$efipartdev")" \
-		|| die "Could not construct /sys path to efi partition"
+		|| die "Could not construct /sys path to EFI partition"
+
+	# Extract partition number, handling both standard and RAID cases
 	local efipartnum
-	efipartnum="$(cat "$sys_efipart/partition")" \
-		|| die "Failed to find partition number for EFI partition $efipartdev"
-	local gptdev
-	gptdev="/dev/$(basename "$(readlink -f "$sys_efipart/..")")" \
-		|| die "Failed to find parent device for EFI partition $efipartdev"
-	if [[ ! -e "$gptdev" ]] || [[ -z "$gptdev" ]]; then
-		gptdev="$(resolve_device_by_id "${DISK_ID_PART_TO_GPT_ID[$DISK_ID_EFI]}")" \
-			|| die "Could not resolve device with id=${DISK_ID_PART_TO_GPT_ID[$DISK_ID_EFI]}"
+	if [[ -e "$sys_efipart/partition" ]]; then
+		efipartnum="$(cat "$sys_efipart/partition")" \
+			|| die "Failed to find partition number for EFI partition $efipartdev"
+	else
+		efipartnum="1" # Assume partition 1 if not found, common for RAID-based EFI
+		einfo "Assuming partition 1 for RAID-based EFI on device $efipartdev"
 	fi
-	try efibootmgr --verbose --create --disk "$gptdev" --part "$efipartnum" --label "gentoo" --loader '\vmlinuz.efi' --unicode 'initrd=\initramfs.img'" $(get_cmdline)"
+
+	einfo "DEBUG: sys_efipart = '$sys_efipart'"
+	einfo "DEBUG: efipartdev = '$efipartdev'"
+	einfo "DEBUG: efipartnum = '$efipartnum'"
+
+	# Identify the parent block device and create EFI boot entry
+	local gptdev
+	if mdadm --detail --scan "$efipartdev" | grep -qE "^ARRAY $efipartdev " && [[ "$efipartdev" =~ ^/dev/md[0-9]+$ ]]; then
+		# RAID 1 case: Create EFI boot entries for each RAID member
+		local raid_members
+		raid_members=($(mdadm --detail "$efipartdev" | sed -n 's|.*active sync[^/]*\(/dev/[^ ]*\).*|\1|p' | sort))
+
+		if [[ ${#raid_members[@]} -eq 0 ]]; then
+			die "RAID setup detected, but no valid member disks found for $efipartdev"
+		fi
+
+		einfo "RAID detected. RAID members: ${raid_members[*]}"
+
+		for disk in "${raid_members[@]}"; do
+			gptdev="$disk"
+			einfo "Adding EFI boot entry for RAID member: $gptdev"
+			try efibootmgr --verbose --create --disk "$gptdev" --part "$efipartnum" --label "gentoo" --loader '\vmlinuz.efi' --unicode "initrd=\\initramfs.img $(get_cmdline)"
+		done
+	else
+		# Non-RAID case: Create a single EFI boot entry
+		gptdev="/dev/$(basename "$(readlink -f "$sys_efipart/..")")" \
+			|| die "Failed to find parent device for EFI partition $efipartdev"
+		if [[ ! -e "$gptdev" ]] || [[ -z "$gptdev" ]]; then
+			gptdev="$(resolve_device_by_id "${DISK_ID_PART_TO_GPT_ID[$DISK_ID_EFI]}")" \
+				|| die "Could not resolve device with id=${DISK_ID_PART_TO_GPT_ID[$DISK_ID_EFI]}"
+		fi
+		try efibootmgr --verbose --create --disk "$gptdev" --part "$efipartnum" --label "gentoo" --loader '\vmlinuz.efi' --unicode 'initrd=\initramfs.img'" $(get_cmdline)"
+	fi
 
 	# Create script to repeat adding efibootmgr entry
 	cat > "/boot/efi/efibootmgr_add_entry.sh" <<EOF
@@ -333,6 +369,14 @@ function generate_fstab() {
 	fi
 }
 
+function generate_mdadm_config() {
+	if [[ $USED_RAID == "true" ]]; then
+		einfo "Saving RAID configuration to /etc/mdadm.conf"
+		echo -e "\n$(mdadm --examine --scan)" >> /etc/mdadm.conf \
+			|| die "Could not write to /etc/mdadm.conf"
+	fi
+}
+
 function main_install_gentoo_in_chroot() {
 	[[ $# == 0 ]] || die "Too many arguments"
 
@@ -344,6 +388,16 @@ function main_install_gentoo_in_chroot() {
 	passwd -d root \
 		|| die "Could not change root password"
 
+	# Sync portage
+	einfo "Syncing portage tree"
+	try emerge-webrsync
+
+	# Install mdadm if we used RAID (needed for UUID resolving)
+	if [[ $USED_RAID == "true" ]]; then
+		einfo "Installing mdadm"
+		try emerge --verbose sys-fs/mdadm
+	fi
+
 	if [[ $IS_EFI == "true" ]]; then
 		# Mount efi partition
 		mount_efivars
@@ -354,10 +408,6 @@ function main_install_gentoo_in_chroot() {
 		einfo "Mounting bios partition"
 		mount_by_id "$DISK_ID_BIOS" "/boot/bios"
 	fi
-
-	# Sync portage
-	einfo "Syncing portage tree"
-	try emerge-webrsync
 
 	# Configure basic system things like timezone, locale, ...
 	maybe_exec 'before_configure_base_system'
@@ -409,13 +459,7 @@ EOF
 	# prevent emerging module before an imminent kernel upgrade
 	try emerge --verbose sys-kernel/dracut sys-kernel/gentoo-kernel-bin app-arch/zstd
 
-	# Install mdadm if we used raid (needed for uuid resolving)
-	if [[ $USED_RAID == "true" ]]; then
-		einfo "Installing mdadm"
-		try emerge --verbose sys-fs/mdadm
-	fi
-
-	# Install cryptsetup if we used luks
+	# Install cryptsetup if we used LUKS
 	if [[ $USED_LUKS == "true" ]]; then
 		einfo "Installing cryptsetup"
 		try emerge --verbose sys-fs/cryptsetup
@@ -429,7 +473,7 @@ EOF
 		try emerge --verbose --changed-use --oneshot sys-apps/systemd
 	fi
 
-	# Install btrfs-progs if we used btrfs
+	# Install btrfs-progs if we used Btrfs
 	if [[ $USED_BTRFS == "true" ]]; then
 		einfo "Installing btrfs-progs"
 		try emerge --verbose sys-fs/btrfs-progs
@@ -437,7 +481,7 @@ EOF
 
 	try emerge --verbose dev-vcs/git
 
-	# Install zfs kernel module and tools if we used zfs
+	# Install ZFS kernel module and tools if we used ZFS
 	if [[ $USED_ZFS == "true" ]]; then
 		einfo "Installing zfs"
 		try emerge --verbose sys-fs/zfs sys-fs/zfs-kmod
@@ -453,6 +497,9 @@ EOF
 			try rc-update add zfs-mount boot
 		fi
 	fi
+
+	# Generate RAID configuration if we used RAID
+	generate_mdadm_config
 
 	# Install kernel and initramfs
 	maybe_exec 'before_install_kernel'

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -172,7 +172,6 @@ function generate_initramfs() {
 		--zstd \
 		--no-hostonly \
 		--ro-mnt \
-		--mdadmconf \
 		--add           "bash ${modules[*]}" \
 		"${dracut_opts[@]}" \
 		--force \
@@ -189,7 +188,6 @@ dracut \\
 	--zstd \\
 	--no-hostonly \\
 	--ro-mnt \\
-	--mdadmconf \\
 	--add           "bash ${modules[*]}" \\
 	${dracut_opts[@]@Q} \\
 	--force \\
@@ -365,14 +363,6 @@ function generate_fstab() {
 	fi
 }
 
-function generate_mdadm_config() {
-	if [[ $USED_RAID == "true" ]]; then
-		einfo "Saving RAID configuration to /etc/mdadm.conf"
-		echo -e "\n$(mdadm --examine --scan)" >> /etc/mdadm.conf \
-			|| die "Could not write to /etc/mdadm.conf"
-	fi
-}
-
 function main_install_gentoo_in_chroot() {
 	[[ $# == 0 ]] || die "Too many arguments"
 
@@ -493,9 +483,6 @@ EOF
 			try rc-update add zfs-mount boot
 		fi
 	fi
-
-	# Generate RAID configuration if we used RAID
-	generate_mdadm_config
 
 	# Install kernel and initramfs
 	maybe_exec 'before_install_kernel'


### PR DESCRIPTION
Hi @oddlama, 

I have tested this implementation for the past two weeks, and everything is working as expected. I’m currently using it on my production servers, but I would really appreciate it if you could review it as well.

Since I primarily use this script for server setups, I’ve compared it with my usual server configuration process, which involves using [Hetzner Installimage Script](https://github.com/hetzneronline/installimage). It would be helpful to hear your thoughts on this and see if you have any recommendations for improvements.

**Areas for review**:

- I know Dracut generally auto-detects RAID arrays. Would it be considered best practice to generate and maintain the `/etc/mdadm.conf` file as part of the process?

**Key fixes include**:

- Ensuring that `--metadata=1.0` is only used on the MD with the ESP, all other MDs should use the latest version (`--metadata=1.2`).
- Making the `/boot/efi` partition redundant in RAID 1 configurations.
- Various minor improvements.

Looking forward to your feedback and suggestions!