### PR TITLE
fix: `error: Could not retrieve list of tarballs`

### DIFF
--- a/configure
+++ b/configure
@@ -424,7 +424,7 @@ function load_default_config() {
 	PORTAGE_GIT_FULL_HISTORY=false
 	PORTAGE_GIT_MIRROR="https://anongit.gentoo.org/git/repo/sync/gentoo.git"
 
-	GENTOO_MIRROR="https://mirror.eu.oneandone.net/linux/distributions/gentoo/gentoo"
+	GENTOO_MIRROR="https://mirror.leaseweb.com/gentoo"
 	GENTOO_ARCH="amd64"
 	GENTOO_SUBARCH=""
 

--- a/gentoo.conf.example
+++ b/gentoo.conf.example
@@ -252,7 +252,7 @@ PORTAGE_GIT_FULL_HISTORY=false
 PORTAGE_GIT_MIRROR="https://anongit.gentoo.org/git/repo/sync/gentoo.git"
 
 # The selected gentoo mirror
-GENTOO_MIRROR="https://mirror.eu.oneandone.net/linux/distributions/gentoo/gentoo"
+GENTOO_MIRROR="https://mirror.leaseweb.com/gentoo"
 #GENTOO_MIRROR="https://distfiles.gentoo.org"
 
 # The architecture of the target system (only tested with amd64)


### PR DESCRIPTION
After debugging, I identified the root cause of the problem:

```sh
Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
Resolving mirror.eu.oneandone.net (mirror.eu.oneandone.net)... 217.72.206.21, 2001:8d8:5c0:404::3
Connecting to mirror.eu.oneandone.net (mirror.eu.oneandone.net)|217.72.206.21|:443... connected.
ERROR: The certificate of 'mirror.eu.oneandone.net' is not trusted.
ERROR: The certificate of 'mirror.eu.oneandone.net' doesn't have a known issuer.
```

To resolve this, I switched to the main Gentoo mirror (DE – Germany) from [the official mirror list](https://www.gentoo.org/downloads/mirrors/), which should provide better reliability.

@oddlama, this is a critical fix as the installer is currently unable to download the tarball list.