### PR TITLE
feat: persist MAKEOPTS to the installed system's make.conf

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -92,6 +92,11 @@ function configure_portage() {
 	touch_or_die 0644 "/etc/portage/package.keywords/zz-autounmask"
 	touch_or_die 0644 "/etc/portage/package.license"
 
+	# Persist the same parallelism used during the install itself (see dispatch_chroot.sh)
+	# so the installed system also builds with sensible defaults, not just this session.
+	echo "MAKEOPTS=\"-j$NPROC\"" >> /etc/portage/make.conf \
+		|| die "Could not modify /etc/portage/make.conf"
+
 	if [[ $SELECT_MIRRORS == "true" ]]; then
 		einfo "Temporarily installing mirrorselect"
 		try emerge --verbose --oneshot app-portage/mirrorselect


### PR DESCRIPTION
`dispatch_chroot.sh` already computes a sensible parallel-build value (`MAKEFLAGS="-j$NPROC"`) for the install process itself, but it was never written to the target system's `/etc/portage/make.conf` — so the installed system fell back to portage's own default instead of inheriting the same value.

This persists `MAKEOPTS` using the same `$NPROC` already exported by `dispatch_chroot.sh`, in `configure_portage()` (`scripts/main.sh`), following the existing pattern already used there for `FEATURES`/`ACCEPT_KEYWORDS`.

Verified: `bash -n` on both changed/entry files, and `tests/shellcheck.sh` before/after — no new findings introduced (the one pre-existing SC2207 warning on an unrelated line just shifted line numbers).

(Drafted with Claude Code's assistance, reviewed by me before submitting.)