### PR TITLE
fix: resolve shellcheck findings (1 real, 3 false positives)

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -249,7 +249,7 @@ function install_kernel_efi() {
 	if mdadm --detail --scan "$efipartdev" | grep -qE "^ARRAY $efipartdev " && [[ "$efipartdev" =~ ^/dev/md[0-9]+$ ]]; then
 		# RAID 1 case: Create EFI boot entries for each RAID member
 		local raid_members
-		raid_members=($(mdadm --detail "$efipartdev" | sed -n 's|.*active sync[^/]*\(/dev/[^ ]*\).*|\1|p' | sort))
+		mapfile -t raid_members < <(mdadm --detail "$efipartdev" | sed -n 's|.*active sync[^/]*\(/dev/[^ ]*\).*|\1|p' | sort)
 
 		if [[ ${#raid_members[@]} -eq 0 ]]; then
 			die "RAID setup detected, but no valid member disks found for $efipartdev"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -229,6 +229,10 @@ function create_resolve_entry() {
 	local type="$2"
 	local arg="${3,,}"
 
+	# shellcheck disable=SC2004 # DISK_ID_TO_RESOLVABLE is associative (declare -gA in
+	# config.sh); the $ is required here to use $id's value as the key, not the literal
+	# string "id" as bash would for an unmarked bareword subscript. shellcheck can't see
+	# the -A declaration from this file, so it wrongly assumes arithmetic-index context.
 	DISK_ID_TO_RESOLVABLE[$id]="$type:$arg"
 }
 
@@ -236,6 +240,7 @@ function create_resolve_entry_device() {
 	local id="$1"
 	local dev="$2"
 
+	# shellcheck disable=SC2004 # see create_resolve_entry() above - same false positive.
 	DISK_ID_TO_RESOLVABLE[$id]="device:$dev"
 }
 
@@ -311,6 +316,9 @@ function parse_arguments() {
 			continue
 		fi
 
+		# shellcheck disable=SC2004 # `arguments` is always declared -A by every caller
+		# (dynamic scope) before this function runs; $key's value is the intended key,
+		# not the literal string "key". shellcheck can't see the caller-side declare.
 		arguments[$key]="$value"
 	done
 


### PR DESCRIPTION
`tests/shellcheck.sh` currently exits 1 (confirmed locally), which would block adding CI to run it automatically. Investigated each of the 4 findings individually rather than applying shellcheck's suggestions blindly:

- **`scripts/main.sh:252` (SC2207) — real issue.** Unquoted command substitution split into an array is fragile (word-splitting/glob pitfalls). Replaced with `mapfile -t`, same result, safer.

- **`scripts/utils.sh:232,239,314` (SC2004 ×3) — false positives.** `DISK_ID_TO_RESOLVABLE` is declared `-gA` (associative) in `config.sh`, and `arguments` is always declared `-A` by every caller of `parse_arguments()` via dynamic scope. shellcheck can't see either declaration from `utils.sh`'s own analysis, so it defaults to assuming arithmetic-index context and suggests dropping the `$` — which would actually be a real bug: an associative-array subscript without `$` uses the literal bareword as the key rather than the variable's value. Suppressed with `shellcheck disable=SC2004` and an explanatory comment at each site rather than "fixing" working code into broken code.

`tests/shellcheck.sh` now exits 0.

(Drafted with Claude Code's assistance, reviewed by me before submitting.)